### PR TITLE
Исправление поведения групп при открытии п/ф

### DIFF
--- a/pizzabot/src/admin/js/Views/PointSTFF/LoadSTFF.js
+++ b/pizzabot/src/admin/js/Views/PointSTFF/LoadSTFF.js
@@ -417,6 +417,10 @@ class LoadSTFF extends React.Component {
         })
     }
 
+    collapseRenderedGroup(e){
+        (e.component).collapseGroup(e.groupIndex);
+    }
+
     render() {
         const {
             actionType,
@@ -465,6 +469,7 @@ class LoadSTFF extends React.Component {
                         hoverStateEnabled={false}
                         activeStateEnabled={false}
                         onItemClick={this.handleMakeMvmntInThisContainer}
+                        onGroupRendered = {this.collapseRenderedGroup}
                         groupRender={(args) => {
                             return (
                                 <div style={{fontSize: '17px'}}>{'Линия п/ф: ' + args.key}</div>
@@ -569,6 +574,7 @@ class LoadSTFF extends React.Component {
                                 hoverStateEnabled={false}
                                 activeStateEnabled={false}
                                 onItemClick={this.handleChooseCellForLoad}
+                                onGroupRendered = {this.collapseRenderedGroup}
                                 groupRender={(args) => {
                                     return (
                                         <div style={{fontSize: '17px'}}>{'Линия п/ф (Контейнер): ' + args.key}</div>

--- a/pizzabot/src/admin/js/Views/PointSTFF/LoadSTFF.js
+++ b/pizzabot/src/admin/js/Views/PointSTFF/LoadSTFF.js
@@ -47,6 +47,12 @@ class LoadSTFF extends React.Component {
             stffCellCode: '',
         }
 
+        this.refs = null
+
+        this.setListRef = element => {
+            this.refs = element
+        }
+
         this.showConfirmationMsg = (messageHtml, title) => {
             return custom({
                 title: title,
@@ -153,6 +159,15 @@ class LoadSTFF extends React.Component {
                 dispatch(changeVisibilityOfLoadingPanel(false));
             }
         )
+        
+    }
+
+    componentDidUpdate(){
+        let list = this.refs.instance
+        var n = this.state.fridgeMap.length
+        for (var i = 0; i < n; i++) {
+            list.collapseGroup(i)
+        }
     }
 
     sendHistoryOfUser() {
@@ -460,7 +475,8 @@ class LoadSTFF extends React.Component {
                     </div>
                 </div>
                 <div className={'pstf_fridge_map'}>
-                    <List 
+                    <List
+                        ref = {this.setListRef}
                         dataSource={fridgeMap}
                         height={'100%'}
                         grouped={true}
@@ -469,7 +485,13 @@ class LoadSTFF extends React.Component {
                         hoverStateEnabled={false}
                         activeStateEnabled={false}
                         onItemClick={this.handleMakeMvmntInThisContainer}
-                        onGroupRendered = {this.collapseRenderedGroup}
+                        //onGroupRendered = {this.collapseRenderedGroup}
+                        /*onContentReady = {(e) => {
+                            var items = e.component.option("items");
+                            for (var i = 0; i < items.length; i++)
+                                e.component.collapseGroup(i);
+                            //console.log(this.listRef)
+                        }}*/
                         groupRender={(args) => {
                             return (
                                 <div style={{fontSize: '17px'}}>{'Линия п/ф: ' + args.key}</div>

--- a/pizzabot_api/bot/botconfig.json
+++ b/pizzabot_api/bot/botconfig.json
@@ -1,4 +1,4 @@
 {
-    "token": "Njg4NzQ0MTU2MDcxMzI5ODc4.XqKOzg.8oNnmv7GdA9rzRHMp4loQFj0P6I",
+    "token": "Njg4NzQ0MTU2MDcxMzI5ODc4.XqPiUQ.Fy1mJfBVTEtssO1Ywd7NmYOVXH0",
     "prefix": "!"
 }


### PR DESCRIPTION
Теперь на страницах с загрузкой П/Ф списки контейнеров изначально закрыты. Такое же поведение и у страницы с линиями П/Ф